### PR TITLE
Add lovely injector patching

### DIFF
--- a/balatro-mobile-maker/Constants.cs
+++ b/balatro-mobile-maker/Constants.cs
@@ -16,6 +16,8 @@ internal static class Constants
     //ADB
     public const string PlatformToolsLink = "https://dl.google.com/android/repository/platform-tools-latest-windows.zip";
 
+    public const string LibLovelyAndroidLink = "https://github.com/kodenamekrak/lovely-injector/releases/latest/download/lovely-aarch64-linux-android.tar.gz";
+
     //OpenJDK Download Links
     //TODO: Find JDK links for all platforms
     //Win


### PR DESCRIPTION
Adds support for adding lovely injector to the android version via https://github.com/kodenamekrak/lovely-injector to load mods at runtime without needing to mess with dump files 

Some mods that use native dependencies wont work (*maybe* ill look into some sort of solution in the future), but most other mods such as cryptid, mobile controls, etc. work just fine. 

The playstack google play version cannot be modded due to DRM